### PR TITLE
YouTubeAds.plugin

### DIFF
--- a/plugin
+++ b/plugin
@@ -1,0 +1,18 @@
+＃youtube去广告，需要版本≤15.26.4
+
+
+[规则]
+^https?:\/\/.+\.googlevideo\.com\/.+&oad url reject-img
+^https?:\/\/.+\.googlevideo\.com\/.+ctier url reject-img
+^https?:\/\/youtubei\.googleapis\.com\/youtubei\/.+ad_ url reject-img
+^https?:\/\/youtubei\.googleapis\.com\/youtubei\/.+log_ url reject-img
+^https?:\/\/.+\.youtube\.com\/get_midroll_ url reject-img
+^https?:\/\/premiumyva\.appspot\.com\/vmclickstoadvertisersite url reject-img
+^https?:\/\/.+\.youtube\.com\/api\/stats\/ads url reject-img
+^https?:\/\/.+\.youtube\.com\/api\/stats\/.+adformat url reject-img
+^https?:\/\/.+\.youtube\.com\/pagead\/ url reject-img
+^https?:\/\/.+\.youtube\.com\/ptracking url reject-img
+
+
+[MITM]
+hostname = *.googlevideo.com, s.youtube.com, www.youtube.com, www.googleapis.com, youtubei.googleapis.com


### PR DESCRIPTION
＃youtube去广告，需要版本≤15.26.4


[规则]
^ https？：\ / \ / .. + \。googlevideo\ .com \ /.+& oad URL reject-img
^ https？：\ / \ / .. + \。googlevideo\ .com \ /.+等级网址拒绝-img
^ https？：\ / \ / youtubei \ .googleapis \ .com \ / youtubei \/。+ad_ url reject-img
^ https？：\ / \ / youtubei \ .googleapis \ .com \ / youtubei \/。+log_ url reject-img
^ https？：\ / \ / /.+ \。youtube\ .com \ / get_midroll_网址拒绝-img
^ https？：\ / \ / premiumyva \ .appspot \ .com \ / vmclickstoadvertiser网站网址拒绝-img
^ https？：\ / \ / .. + \。youtube\ .com \ / api \ /统计\ /广告网址reject-img
^ https？：\ / \ /.+ \。youtube\ .com \ / api \ / stats \ /..+广告格式网址拒绝-img
^ https？：\ / \ / .. + \。youtube\ .com \ / pagead \ /网址拒绝-img
^ https？：\ / \ / .. + \。youtube\ .com \ / ptracking网址reject-img


[MITM]
主机名= * .googlevideo.com，s.youtube.com，www.youtube.com，www.googleapis.com，youtubei.googleapis.com
